### PR TITLE
feat(ui): add selected state to buttons

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -90,3 +90,6 @@
   display: block;
   margin: -1rem 0 2rem;
 }
+.selected {
+  background-color: grey;
+}

--- a/lib/barquinhos/game/ship.ex
+++ b/lib/barquinhos/game/ship.ex
@@ -20,11 +20,11 @@ defmodule Barquinhos.Game.Ship do
   defp get_size(:battleship), do: 4
   defp get_size(:carrier), do: 5
 
-  def to_points(%Ship{orientation: :vertical, starting_point: {x, y}} = ship) do
+  def to_points(%Ship{orientation: :horizontal, starting_point: {x, y}} = ship) do
     for n <- y..(y - 1 + ship.size), do: {x, n}
   end
 
-  def to_points(%Ship{orientation: :horizontal, starting_point: {x, y}} = ship) do
+  def to_points(%Ship{orientation: :vertical, starting_point: {x, y}} = ship) do
     for n <- x..(x - 1 + ship.size), do: {n, y}
   end
 

--- a/lib/barquinhos_web/live/game_live.html.leex
+++ b/lib/barquinhos_web/live/game_live.html.leex
@@ -6,14 +6,14 @@
     </pre>
 </section>
 <div>
-    <p><button phx-click="ship_orientation" phx-value-orientation="horizontal">horizontal</button></p>
-    <p><button phx-click="ship_orientation" phx-value-orientation="vertical">vertical</button></p>
+    <p><button class="<%= if @ship_orientation == :horizontal, do: "selected"%>" phx-click="ship_orientation" phx-value-orientation="horizontal">horizontal</button></p>
+    <p><button class="<%= if @ship_orientation == :vertical, do: "selected"%>" phx-click="ship_orientation" phx-value-orientation="vertical">vertical</button></p>
 </div>
 <div>
-    <p><button phx-click="ship_type" phx-value-type="submarine">submarine</button></p>
-    <p><button phx-click="ship_type" phx-value-type="destroyer">destroyer</button></p>
-    <p><button phx-click="ship_type" phx-value-type="battleship">battleship</button></p>
-    <p><button phx-click="ship_type" phx-value-type="carrier">carrier</button></p>
+    <p><button class="<%= if @ship_type == :submarine, do: "selected"%>" phx-click="ship_type" phx-value-type="submarine">submarine</button></p>
+    <p><button class="<%= if @ship_type == :destroyer, do: "selected"%>" phx-click="ship_type" phx-value-type="destroyer">destroyer</button></p>
+    <p><button class="<%= if @ship_type == :battleship, do: "selected"%>" phx-click="ship_type" phx-value-type="battleship">battleship</button></p>
+    <p><button class="<%= if @ship_type == :carrier, do: "selected"%>" phx-click="ship_type" phx-value-type="carrier">carrier</button></p>
 </div>
 <section class="board">
     <%= for x <- 0..9, y <- 0..9 do %>


### PR DESCRIPTION
Now when the ship orientation and type buttons are selected in the socket, they will remain grey.

Also a small change to swap orientations so that they match what is appearing in the UI. 